### PR TITLE
add dockerfile, ghcr workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,30 @@
+name: Docker Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build_and_push:
+    name: Build & Publish Docker Images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/wireguard-vanity-key:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:latest AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 go build
+
+FROM scratch
+LABEL org.opencontainers.image.url=https://github.com/AlexanderYastrebov/wireguard-vanity-key \
+  org.opencontainers.image.licenses=BSD-3-Clause
+COPY --from=builder /app/wireguard-vanity-key /wireguard-vanity-key
+ENTRYPOINT ["/wireguard-vanity-key"]


### PR DESCRIPTION
Not sure how you want it documented, but an alternative way of running it is

```
docker run ghcr.io/AlexanderYastrebov/wireguard-vanity-key:latest --prefix=2025
```

test was not included