### PR TITLE
Update filippo.io/edwards25519

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ docker run ghcr.io/alexanderyastrebov/wireguard-vanity-key:latest --prefix=202
 
 ## Benchmark
 
-The tool checks ~10'000'000 keys per second on a test machine:
+The tool checks ~12'000'000 keys per second on a test machine:
 
 ```console
 $ go test . -run=NONE -bench=BenchmarkFindPointParallel -benchmem -count=10
@@ -39,16 +39,16 @@ goos: linux
 goarch: amd64
 pkg: github.com/AlexanderYastrebov/wireguard-vanity-key
 cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
-BenchmarkFindPointParallel-8    10849304               103.0 ns/op             0 B/op          0 allocs/op
-BenchmarkFindPointParallel-8    11097517               102.7 ns/op             0 B/op          0 allocs/op
-BenchmarkFindPointParallel-8    11212604               102.3 ns/op             0 B/op          0 allocs/op
-BenchmarkFindPointParallel-8    11036245               102.7 ns/op             0 B/op          0 allocs/op
-BenchmarkFindPointParallel-8    10965774               102.3 ns/op             0 B/op          0 allocs/op
-BenchmarkFindPointParallel-8    11179293               106.1 ns/op             0 B/op          0 allocs/op
-BenchmarkFindPointParallel-8     9909200               114.3 ns/op             0 B/op          0 allocs/op
-BenchmarkFindPointParallel-8    10143001               113.3 ns/op             0 B/op          0 allocs/op
-BenchmarkFindPointParallel-8    10122814               113.1 ns/op             0 B/op          0 allocs/op
-BenchmarkFindPointParallel-8    10073284               112.5 ns/op             0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    13230948                86.06 ns/op            0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    13185460                87.24 ns/op            0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    12931213                88.63 ns/op            0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    12287206                89.30 ns/op            0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    12603378                90.61 ns/op            0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    12401572                91.26 ns/op            0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    12177254                93.40 ns/op            0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    12052425                92.88 ns/op            0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    12028226                93.76 ns/op            0 B/op          0 allocs/op
+BenchmarkFindPointParallel-8    12186556                93.87 ns/op            0 B/op          0 allocs/op
 PASS
 ok      github.com/AlexanderYastrebov/wireguard-vanity-key      21.154s
 ```

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/AlexanderYastrebov/wireguard-vanity-key
 
 go 1.23.2
 
-require filippo.io/edwards25519 v1.1.1-0.20250205130949-eef06506605b
+require filippo.io/edwards25519 v1.1.1-0.20250207174519-4c39688abc49

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-filippo.io/edwards25519 v1.1.1-0.20250205130949-eef06506605b h1:YAGF3iPfThAWSDW4uiCsfiBdi79e6x1HIivdv8Iibv0=
-filippo.io/edwards25519 v1.1.1-0.20250205130949-eef06506605b/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/edwards25519 v1.1.1-0.20250207174519-4c39688abc49 h1:Nk9anH0ljq5ejXc2n5HTAtPj2JNJPbiV7buAzFb70rM=
+filippo.io/edwards25519 v1.1.1-0.20250207174519-4c39688abc49/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=


### PR DESCRIPTION
Update to include https://github.com/FiloSottile/edwards25519/pull/50 improvement.
```
goos: linux
goarch: amd64
pkg: github.com/AlexanderYastrebov/wireguard-vanity-key cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                      │ origin/main │                HEAD                 │
                      │   sec/op    │   sec/op     vs base                │
FindBatchPoint/1024-8   425.1n ± 0%   373.8n ± 0%  -12.07% (p=0.000 n=10)

                      │ origin/main │              HEAD              │
                      │    B/op     │    B/op     vs base            │
FindBatchPoint/1024-8    0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                      │ origin/main │              HEAD              │
                      │  allocs/op  │ allocs/op   vs base            │
FindBatchPoint/1024-8    0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```