### PR TITLE
Implement blind search

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ PASS
 ok      github.com/AlexanderYastrebov/wireguard-vanity-key      21.154s
 ```
 
+## Blind search
+
+The tool supports blind search, i.e. when worker does not know the private key, see [demo-blind.sh](demo-blind.sh).
+
 ## Similar projects
 
 * [wireguard-vanity-address](https://github.com/warner/wireguard-vanity-address)

--- a/demo-blind.sh
+++ b/demo-blind.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# This script demonstrates blind prefix search,
+# i.e. when worker does not know the private key.
+#
+
+prefix=AY/
+
+# Generate secure staring private key
+private=$(wg genkey)
+
+# and its public key
+public=$(echo $private | wg pubkey)
+
+# Search for prefix by incrementing $public key and report result offset.
+# Note that $private key is not involved and search can be scaled horizontally.
+offset=$(wireguard-vanity-key --prefix=$prefix --public=$public --output=offset)
+
+# Generate new private vanity key by offsetting the starting $private key.
+# Give it the $prefix to choose from two possible results.
+private_vanity=$(echo $private | wireguard-vanity-key add --offset=$offset --prefix=$prefix)
+
+# Print vanity key pair
+echo $private_vanity
+echo $private_vanity | wg pubkey

--- a/main_test.go
+++ b/main_test.go
@@ -147,3 +147,24 @@ func TestTestBase64Prefix(t *testing.T) {
 	assertEqual(true, testBase64Prefix("AAA")([]byte{0, 0, 0}))
 	assertEqual(true, testBase64Prefix("AAA")([]byte{0, 0, 0b00_000001}))
 }
+
+func TestParsePublicKey(t *testing.T) {
+	for _, pk := range []string{
+		"QiyOemIn17yhNQs+K7cnn3iXuHu2hUt4PGDoAxGuMHk=",
+		"vQnB//PF0URzwwsH0b1ff7a0P3jLKbrOCdLiTkWkvQA=",
+		"3nN+Tj4J/e99YWD6TFMvhfMNJCrORoSf8ommtXeXvBs=",
+		"Fo8iOSvqtfDjtBALpwGALNiwaZNgMrQYXIEDB2oU6lQ=",
+		"YR3nSufwy4r5FuCE7GujLSLssyVJ6iKy2utbUCQelh4=",
+	} {
+		t.Run(pk, func(t *testing.T) {
+			p, err := parsePublicKey(pk)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got := base64.StdEncoding.EncodeToString(p.BytesMontgomery()); got != pk {
+				t.Errorf("pk: %s, got: %s", pk, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enable search using untrusted workers that only require starting public key.

See demo-blind.sh.
See also https://github.com/warner/wireguard-vanity-address/issues/1