### PR TITLE
Use field.Element for offsetting

### DIFF
--- a/demo-blind.sh
+++ b/demo-blind.sh
@@ -3,8 +3,9 @@
 # This script demonstrates blind prefix search,
 # i.e. when worker does not know the private key.
 #
+set -euo pipefail
 
-prefix=AY/
+prefix=${1:-AY/}
 
 # Generate secure staring private key
 private=$(wg genkey)


### PR DESCRIPTION
Use field.Element instead of edwards25519.Scalar
to preserve clamping since Scalar values are always reduced modulo the prime order of the curve l = 2^252 + 27742317777372353535851937790883648493 and hence do not preserve clamping.