### PR TITLE
Use offset coordinate symmetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ $ docker run  ghcr.io/alexanderyastrebov/wireguard-vanity-key:latest -prefix=202
 
 ## Performance
 
-The tool checks ~26'000'000 keys per second on a test machine:
+The tool checks ~29'000'000 keys per second on a test machine:
 
 ```console
 $ go run . -prefix=GoodLuckWithThisPrefix -timeout=20s
 private                                      public                                       attempts   duration   attempts/s
--                                            GoodLuckWithThisPrefix...                    520729600  20s        26016401
+-                                            GoodLuckWithThisPrefix...                    583920640  20s        29194831
 ```
 
 In practice it finds 4-character prefix in a second and 5-character prefix in a minute:


### PR DESCRIPTION
A point `q` and negative `q' = -q` have the same `Y' = Y` and negated `X' = -X` coordinates.

This can be used to save a multiplication per batch item by changing batch from
`batch = {p, p + pointOffset, p + 2*pointOffset, ... , p + batchSize*pointOffset}` to
`batch = {p - batchSize/2*pointOffset, ... , p, ... , p + batchSize/2*pointOffset}`
and reusing intermediate multiplication results for `q = i*pointOffset` and `q' = -i*pointOffset`.

This change also enables zero-length batch, i.e. testing one point per iteration.

```
goos: linux
goarch: amd64
pkg: github.com/AlexanderYastrebov/wireguard-vanity-key
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                      │    main     │                HEAD                 │
                      │   sec/op    │   sec/op     vs base                │
FindBatchPoint/1024-8   172.4n ± 3%   154.7n ± 1%  -10.29% (p=0.000 n=10)
```